### PR TITLE
Issue #1 - Batch Annotator

### DIFF
--- a/annotations/annotator.go
+++ b/annotations/annotator.go
@@ -1,0 +1,60 @@
+package annotations
+
+import (
+	"regexp"
+
+	"github.com/axiomabsolute/gramme/primitives"
+)
+
+// AnnotateBuffer - Generates Buffer annotations for text
+func AnnotateBuffer(text string) []Annotation {
+	textLength := primitives.Cursor(len(text))
+	return []Annotation{
+		{
+			Tag: BUFFER,
+			Region: primitives.Region{
+				Left:  primitives.Span{A: 0, B: 0},
+				Right: primitives.Span{A: textLength, B: textLength},
+			},
+		},
+	}
+}
+
+// AnnotateByDelimiter - Given a pattern that defines a delimiter, annotate the given text into overlapping regions
+func AnnotateByDelimiter(tag Tag, delimiter *regexp.Regexp, text string) []Annotation {
+	matches := delimiter.FindAllStringIndex(text, -1)
+	results := []Annotation{}
+	for i := 0; i < len(matches)-1; i++ {
+		left := matches[i]
+		right := matches[i+1]
+
+		leftSpan := primitives.Span{A: primitives.Cursor(left[0]), B: primitives.Cursor(left[1])}
+		rightSpan := primitives.Span{A: primitives.Cursor(right[0]), B: primitives.Cursor(right[1])}
+
+		annotation := Annotation{Tag: tag, Region: primitives.Region{Left: leftSpan, Right: rightSpan}}
+		results = append(results, annotation)
+	}
+	return results
+}
+
+// AnnotateLines - Generate annotations for lines, separated by one more more newline characters
+func AnnotateLines(text string) []Annotation {
+	pattern := regexp.MustCompile("\\A|\n+|\\z")
+	return AnnotateByDelimiter(LINE, pattern, text)
+}
+
+// AnnotateWords - Generate annotations for wods, separated by punctuation or whitespace
+func AnnotateWords(text string) []Annotation {
+	pattern := regexp.MustCompile("\\A|\\n|[\\.,!?]?\\s+|\\z")
+	return AnnotateByDelimiter(WORD, pattern, text)
+}
+
+// BatchAnnotate - Given a set of annotators, run each on the text and merge results
+func BatchAnnotate(annotators []Annotator, text string) []Annotation {
+	results := []Annotation{}
+	for _, annotator := range annotators {
+		annotations := annotator(text)
+		results = append(results, annotations...)
+	}
+	return results
+}

--- a/annotations/annotator_test.go
+++ b/annotations/annotator_test.go
@@ -1,0 +1,60 @@
+package annotations
+
+import (
+	"testing"
+
+	"github.com/axiomabsolute/gramme/primitives"
+)
+
+const testText = `The limerick packs laughs anatomical
+Into space that is quite economical.
+But the good ones I've seen
+So seldom are clean
+And the clean ones so seldom are comical.`
+
+func TestAnnotateBuffer(t *testing.T) {
+	result := AnnotateBuffer(testText)
+	if len(result) != 1 {
+		t.Errorf("AnnotateBuffer(..) should return exactly one annotation")
+	}
+	bufferAnnotation := result[0]
+	if bufferAnnotation.Left.A != 0 {
+		t.Errorf("Buffer annotation should start at 0")
+	}
+	if bufferAnnotation.Left.B != 0 {
+		t.Errorf("Buffer annotation left region should be empty")
+	}
+	if bufferAnnotation.Right.A != primitives.Cursor(len(testText)) {
+		t.Errorf("Buffer annotation should end at the full text")
+	}
+	if bufferAnnotation.Right.B != bufferAnnotation.Right.A {
+		t.Errorf("Buffer annotation right region should be empty")
+	}
+}
+
+func TestAnnotateLines(t *testing.T) {
+	result := AnnotateLines(testText)
+	if len(result) != 5 {
+		t.Errorf("AnnotateLines(..) should return 5 lines")
+	}
+}
+
+func TestAnnotateWords(t *testing.T) {
+	result := AnnotateWords(testText)
+	if len(result) != 29 {
+		t.Errorf("AnnotateWords(..) should return 29 words")
+	}
+	spotCheck := GetAnnotatedText(testText, result[10])
+	expect := []string{
+		` `,
+		`economical`,
+		`.
+`,
+	}
+	for i, expected := range expect {
+		if spotCheck[i] != expected {
+			t.Errorf("AnnotateWords(..)[10] - Expected result[%v] to be `%v` but found `%v`", i, expected, spotCheck[i])
+		}
+	}
+
+}

--- a/annotations/primitives.go
+++ b/annotations/primitives.go
@@ -1,0 +1,21 @@
+package annotations
+
+import "github.com/axiomabsolute/gramme/primitives"
+
+// Tag - A type tag for annotations
+type Tag int
+
+const (
+	// BUFFER - An entire file's content
+	BUFFER Tag = iota
+	// LINE - A newline delimited piece of text
+	LINE
+	// WORD - A whitespace or punctuation delimited sequence of text
+	WORD
+)
+
+// Annotation - A tagged region of text
+type Annotation struct {
+	Tag Tag
+	primitives.Region
+}

--- a/annotations/primitives.go
+++ b/annotations/primitives.go
@@ -2,6 +2,9 @@ package annotations
 
 import "github.com/axiomabsolute/gramme/primitives"
 
+// Annotator - A function that analyzes a source text and produces a slice of Annotations
+type Annotator func(text string) []Annotation
+
 // Tag - A type tag for annotations
 type Tag int
 
@@ -18,4 +21,14 @@ const (
 type Annotation struct {
 	Tag Tag
 	primitives.Region
+}
+
+// GetAnnotatedText - Returns 3 string; the left delimiter, annotated region, and right delimiter
+func GetAnnotatedText(text string, annotation Annotation) []string {
+	left := text[annotation.Left.A:annotation.Left.B]
+	middle := text[annotation.Left.B:annotation.Right.A]
+	right := text[annotation.Right.A:annotation.Right.B]
+	return []string{
+		left, middle, right,
+	}
 }

--- a/annotations/query.go
+++ b/annotations/query.go
@@ -1,0 +1,27 @@
+package annotations
+
+import (
+	"github.com/axiomabsolute/gramme/primitives"
+)
+
+// OfTag - Filters a slice of annotations by Tag
+func OfTag(annotations []Annotation, tag Tag) []Annotation {
+	results := []Annotation{}
+	for _, annotation := range annotations {
+		if annotation.Tag == tag {
+			results = append(results, annotation)
+		}
+	}
+	return results
+}
+
+// Containing - Filters a slice of annotations by cursor inclusion
+func Containing(annotations []Annotation, cursor primitives.Cursor) []Annotation {
+	results := []Annotation{}
+	for _, annotation := range annotations {
+		if annotation.Left.A <= cursor && annotation.Right.B >= cursor {
+			results = append(results, annotation)
+		}
+	}
+	return results
+}

--- a/primitives/primitives.go
+++ b/primitives/primitives.go
@@ -1,0 +1,17 @@
+package primitives
+
+// Cursor - An offset-based location relative to the start of a file
+type Cursor int
+
+// Span - A sequence of text represented by the text between two cursor positions.
+type Span struct {
+	A Cursor
+	B Cursor
+}
+
+// Region - A delimited sequence of text represented by two non-overlapping spans (the delimiters) and
+// the implicit span between them.
+type Region struct {
+	Left  Span
+	Right Span
+}


### PR DESCRIPTION
Implements a batch text feature annotator, which provides general text feature annotation, extracting features such as lines and words, along with the full buffer. These annotations will be used to support structural editing via Gramme's command language. Future iterations will support mode-based feature annotation as well, such as annotating *functions* using programming language specific definitions, etc.

## Summary of Changes

- Defined generic delimiter-based annotator function
- Derive `Line` and `Word` annotators based on that
- Define primitives for `Region`, `Span`, `Cursor`, and `Annotation`
- Implement naive batch annotation
- Unit tests
- Add basic methods to filter annotations by type and cursor incluusion

## Limitations

This is purposefully not intended to be useful as the basis of an interactive editor and will likely demonstrate unacceptable performance for on-edit updates for even moderately sized files, long term. It's a PoC to help bootstrap development only